### PR TITLE
feat!: Add scanning for unmanaged files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -329,6 +329,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +375,37 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
  "rayon",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -408,6 +474,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +516,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +566,28 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indoc"
@@ -548,6 +670,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,24 +728,30 @@ dependencies = [
  "os_info",
  "paketkoll_core",
  "proc-exit",
+ "rayon",
 ]
 
 [[package]]
 name = "paketkoll_core"
 version = "0.2.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "bitflags 2.4.2",
  "bstr",
  "compact_str",
  "dashmap",
+ "derive_builder",
  "either",
  "flate2",
+ "flume",
  "hex",
+ "ignore",
  "indoc",
  "lasso",
  "log",
  "md-5",
+ "num_cpus",
  "phf",
  "pretty_assertions",
  "rayon",
@@ -622,7 +760,6 @@ dependencies = [
  "rust-ini",
  "smallvec",
  "strum",
- "typed-builder",
 ]
 
 [[package]]
@@ -837,6 +974,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,12 +1025,21 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -935,26 +1090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-builder"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444d8748011b93cb168770e8092458cb0f8854f931ff82fdf6ddfbd72a9c933e"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1150,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/paketkoll/Cargo.toml
+++ b/crates/paketkoll/Cargo.toml
@@ -29,6 +29,7 @@ log = "0.4.21"
 os_info = { version = "3.7.0", default-features = false }
 paketkoll_core = { version = "0.2.0", path = "../paketkoll_core" }
 proc-exit = "2.0.1"
+rayon = "1.9.0"
 
 [build-dependencies]
 clap = { version = "4.5.2", features = ["derive"] }

--- a/crates/paketkoll/src/cli.rs
+++ b/crates/paketkoll/src/cli.rs
@@ -1,9 +1,10 @@
 use std::fmt::Display;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
+#[command(propagate_version = true)]
 pub(crate) struct Cli {
     /// Trust mtime (don't check checksum if it matches)
     #[arg(long)]
@@ -14,8 +15,29 @@ pub(crate) struct Cli {
     /// Which package manager backend to use
     #[arg(short, long, default_value_t = Backend::Auto)]
     pub(crate) backend: Backend,
-    /// Packages to check (default: all of them)
-    pub(crate) packages: Vec<String>,
+    /// Operation to perform
+    #[command(subcommand)]
+    pub(crate) command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum Commands {
+    /// Check package files
+    Check {
+        /// Packages to check (default: all of them)
+        packages: Vec<String>,
+    },
+    /// Check package files and search for unexpected files
+    CheckUnexpected {
+        /// Paths to ignore (apart from built in ones). Basic globs are supported.
+        /// Use ** to match any number of path components.
+        #[arg(long)]
+        ignore: Vec<String>,
+        /// Should paths be canonicalized before checking? If you get many false positives, try this.
+        /// Required on Debian due to lack of /usr merge.
+        #[arg(long)]
+        canonicalize: bool,
+    },
 }
 
 /// Determine which package manager backend to use

--- a/crates/paketkoll_core/Cargo.toml
+++ b/crates/paketkoll_core/Cargo.toml
@@ -37,14 +37,18 @@ __md5 = ["dep:md-5"]
 __sha256 = ["dep:ring"]
 
 [dependencies]
+ahash = "0.8.11"
 anyhow = { version = "1.0.80", features = ["backtrace"] }
 bitflags = "2.4.2"
 bstr = "1.9.1"
 compact_str = { version = "0.7.1", features = ["smallvec"] }
 dashmap = { version = "5.5.3", optional = true }
+derive_builder = "0.20.0"
 either = "1.10.0"
 flate2 = { version = "1.0.28", features = ["zlib-ng"], optional = true }
+flume = { version = "0.11.0", default-features = false }
 hex = "0.4.3"
+ignore = { version = "0.4.22", features = ["simd-accel"] }
 lasso = { version = "0.7.2", features = [
     "ahasher",
     "inline-more",
@@ -52,6 +56,7 @@ lasso = { version = "0.7.2", features = [
 ] }
 log = "0.4.21"
 md-5 = { version = "0.10.6", optional = true }
+num_cpus = "1.16.0"
 #mtree = { version = "0.5.0", optional = true }
 phf = { version = "0.11.2", features = ["macros"] }
 rayon = "1.9.0"
@@ -64,7 +69,6 @@ smallvec = { version = "1.13.1", features = [
     "union",
 ] }
 strum = { version = "0.26.1", features = ["derive"] }
-typed-builder = "0.18.1"
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/crates/paketkoll_core/src/backend.rs
+++ b/crates/paketkoll_core/src/backend.rs
@@ -1,9 +1,16 @@
 //! The various backends implementing distro specific support
 
+use std::{
+    os::unix::ffi::OsStrExt,
+    path::{Path, PathBuf},
+};
+
 use anyhow::Context;
+use dashmap::DashMap;
+use ignore::{overrides::OverrideBuilder, Match, WalkBuilder, WalkState};
 use rayon::prelude::*;
 
-use crate::types::{Issue, IssueKind, PackageInterner, PackageRef};
+use crate::types::{FileEntry, Issue, IssueKind, PackageInterner, PackageIssue};
 
 #[cfg(feature = "arch_linux")]
 pub(crate) mod arch;
@@ -15,11 +22,8 @@ pub(crate) mod filesystem;
 
 /// Check file system for differences using the given configuration
 pub fn check(
-    config: &crate::config::CheckConfiguration,
-) -> anyhow::Result<(
-    crate::types::PackageInterner,
-    impl Iterator<Item = (Option<PackageRef>, Issue)>,
-)> {
+    config: &crate::config::CommonConfiguration,
+) -> anyhow::Result<(crate::types::PackageInterner, Vec<PackageIssue>)> {
     let backend = config
         .backend
         .create(config)
@@ -53,7 +57,234 @@ pub fn check(
         )
         .collect();
 
-    Ok((interner, mismatches.into_iter()))
+    Ok((interner, mismatches))
+}
+
+/// Check file system for differences (including unexpected files) using the given configuration
+pub fn check_unexpected(
+    common_cfg: &crate::config::CommonConfiguration,
+    unexpected_cfg: &crate::config::CheckUnexpectedConfiguration,
+) -> anyhow::Result<(crate::types::PackageInterner, Vec<PackageIssue>)> {
+    // Collect distro files
+    let backend = common_cfg
+        .backend
+        .create(common_cfg)
+        .with_context(|| format!("Failed to create backend for {}", common_cfg.backend))?;
+    let interner = PackageInterner::new();
+    // Get distro specific file list
+    let mut results = backend.files(&interner).with_context(|| {
+        format!(
+            "Failed to collect information from backend {}",
+            common_cfg.backend
+        )
+    })?;
+
+    // Possibly canonicalize paths
+    if unexpected_cfg.canonicalize_paths {
+        log::debug!(target: "paketkoll_core::backend", "Canonicalizing paths");
+        canonicalize_file_entries(&mut results);
+    }
+
+    log::debug!(target: "paketkoll_core::backend", "Preparing data structures");
+    // We want a hashmap from path to data here.
+    let path_map: DashMap<&Path, &FileEntry, ahash::RandomState> =
+        DashMap::with_capacity_and_hasher(results.len(), ahash::RandomState::new());
+    results.par_iter().for_each(|file_entry| {
+        path_map.insert(&file_entry.path, file_entry);
+    });
+
+    // Build glob set of ignores
+    let overrides = {
+        let mut builder = OverrideBuilder::new("/");
+        // Add standard ignores
+        for pattern in BUILTIN_IGNORES {
+            builder.add(pattern).expect("Builtin ignore failed");
+        }
+        // Add user ignores
+        for pattern in &unexpected_cfg.ignored_paths {
+            builder.add(&("!".to_string() + pattern.as_str()))?;
+        }
+        builder.build()?
+    };
+
+    log::debug!(target: "paketkoll_core::backend", "Walking file system");
+    let walker = WalkBuilder::new("/")
+        .hidden(false)
+        .parents(false)
+        .ignore(false)
+        .overrides(overrides.clone())
+        .git_global(false)
+        .git_ignore(false)
+        .git_exclude(false)
+        .follow_links(false)
+        .same_file_system(false)
+        .threads(num_cpus::get())
+        .build_parallel();
+
+    let (collector, collected_issues) = flume::unbounded();
+
+    walker.run(|| {
+        Box::new(|entry| {
+            match entry {
+                Ok(entry) => {
+                    let path = entry.path();
+                    if let Some(file_entry) = path_map.get(path) {
+                        file_entry
+                            .seen
+                            .store(true, std::sync::atomic::Ordering::Relaxed);
+                        match filesystem::check_file(&file_entry, common_cfg) {
+                            Ok(Some(inner)) => {
+                                collector
+                                    .send((file_entry.package, inner))
+                                    .expect("Unbounded queue");
+                            }
+                            Ok(None) => (),
+                            Err(err) => {
+                                let issues =
+                                    smallvec::smallvec![IssueKind::FsCheckError(Box::new(err))];
+                                collector
+                                    .send((
+                                        file_entry.package,
+                                        Issue::new(file_entry.path.clone(), issues),
+                                    ))
+                                    .expect("Unbounded queue");
+                            }
+                        }
+                    } else {
+                        // Unexpected file found
+                        collector
+                            .send((
+                                None,
+                                Issue::new(
+                                    path.to_path_buf(),
+                                    smallvec::smallvec![IssueKind::Unexpected],
+                                ),
+                            ))
+                            .expect("Unbounded queue");
+                    }
+                }
+                Err(ignore_err) => {
+                    collector
+                        .send(interpret_ignore_error(ignore_err, None))
+                        .expect("Unbounded queue");
+                }
+            }
+            WalkState::Continue
+        })
+    });
+
+    // Identify missing files (we should have seen them walking through the file system)
+    results.par_iter().for_each(|file_entry| {
+        if file_entry.seen.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+        if let Match::Ignore(_) = overrides.matched(
+            &file_entry.path,
+            file_entry.properties.is_dir().unwrap_or(false),
+        ) {
+            return;
+        }
+        collector
+            .send((
+                file_entry.package,
+                Issue::new(
+                    file_entry.path.clone(),
+                    smallvec::smallvec![IssueKind::Missing],
+                ),
+            ))
+            .expect("Unbounded queue");
+    });
+
+    // Collect all items from queue into vec
+    let mut mismatches = Vec::new();
+    for item in collected_issues.drain() {
+        mismatches.push(item);
+    }
+
+    // Drop on a background thread, this help a bit.
+    drop(path_map);
+    rayon::spawn(move || {
+        drop(results);
+    });
+
+    Ok((interner, mismatches))
+}
+
+/// Canonicalize paths in file entries.
+///
+/// This is needed for Debian as packages don't make sense wrt /usr-merge
+fn canonicalize_file_entries(results: &mut Vec<FileEntry>) {
+    results.par_iter_mut().for_each(|file_entry| {
+        if file_entry.path.as_os_str().as_bytes() == b"/" {
+            return;
+        }
+        // We only want to canonicalize the parenting path, not the file itself,
+        // otherwise we can't check properties of symlinks. Since Debian doesn't
+        // tell us what is a symlink or not, just use the parent path.
+        let parent = file_entry.path.parent();
+        let filename = file_entry.path.file_name();
+        match (parent, filename) {
+            (Some(parent), Some(filename)) => {
+                match parent.canonicalize() {
+                    Ok(canonical_parent) => {
+                        // We only need to do work here if the parent path actually changed (saves ~10 ms).
+                        if canonical_parent != parent {
+                            file_entry.path = canonical_parent.join(filename);
+                        }
+                    }
+                    Err(err) => {
+                        log::error!(
+                            "Failed to canonicalize path: {:?} ({:?})",
+                            file_entry.path,
+                            err
+                        );
+                    }
+                }
+            }
+            (None, _) => log::error!("Failed to resolve parent of path: {:?}", file_entry.path),
+            (_, None) => {
+                log::error!("Failed to resolve filenameI of path: {:?}", file_entry.path)
+            }
+        }
+    });
+}
+
+/// Attempt to make sense of the errors from the "ignore" crate.
+///
+/// This involves recursively mapping into some of the variants to find the actual error.
+fn interpret_ignore_error(ignore_err: ignore::Error, context: Option<PathBuf>) -> PackageIssue {
+    match ignore_err {
+        ignore::Error::Partial(_) | ignore::Error::WithLineNumber { .. } => {
+            unreachable!("We don't parse ignore files")
+        }
+        ignore::Error::InvalidDefinition | ignore::Error::UnrecognizedFileType(_) => {
+            unreachable!("File types not used")
+        }
+        ignore::Error::Glob { .. } => unreachable!("We don't use globs from ignores"),
+        ignore::Error::WithPath { path, err } => interpret_ignore_error(*err, Some(path)),
+        ignore::Error::WithDepth { depth: _, err } => interpret_ignore_error(*err, None),
+        ignore::Error::Loop { .. } => unreachable!("We don't follow symlinks"),
+        ignore::Error::Io(io_error) => match io_error.kind() {
+            std::io::ErrorKind::PermissionDenied => (
+                None,
+                Issue::new(
+                    context.unwrap_or_else(|| PathBuf::from("UNKNOWN_PATH")),
+                    smallvec::smallvec![IssueKind::PermissionDenied],
+                ),
+            ),
+            _ => {
+                let issues =
+                    smallvec::smallvec![IssueKind::FsCheckError(Box::new(io_error.into()))];
+                (
+                    None,
+                    Issue::new(
+                        context.unwrap_or_else(|| PathBuf::from("UNKNOWN_PATH")),
+                        issues,
+                    ),
+                )
+            }
+        },
+    }
 }
 
 pub(crate) trait Name {
@@ -88,3 +319,17 @@ pub(crate) trait Packages: Name {
 // - Get source file from package (possibly downloading the package to cache if needed)
 // - Does a paccache equivalent exist for Debian or do we need to implement smart cache
 //   cleaning as a separate tool?
+
+const BUILTIN_IGNORES: &[&str] = &[
+    "!**/lost+found",
+    "!/dev/",
+    "!/home/",
+    "!/media/",
+    "!/mnt/",
+    "!/proc/",
+    "!/root/",
+    "!/run/",
+    "!/sys/",
+    "!/tmp/",
+    "!/var/tmp/",
+];

--- a/crates/paketkoll_core/src/backend/arch/mtree.rs
+++ b/crates/paketkoll_core/src/backend/arch/mtree.rs
@@ -90,6 +90,7 @@ fn convert_mtree(
                     path,
                     properties: Properties::Directory(dir),
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 })
             } else {
                 None
@@ -111,6 +112,7 @@ fn convert_mtree(
             } else {
                 FileFlags::empty()
             },
+            seen: Default::default(),
         }),
         Some(mtree::FileType::SymbolicLink) => Some(FileEntry {
             package: Some(pkg),
@@ -121,6 +123,7 @@ fn convert_mtree(
                 target: item.link().context("No target for link")?.into(),
             }),
             flags: FileFlags::empty(),
+            seen: Default::default(),
         }),
         Some(mtree::FileType::BlockDevice)
         | Some(mtree::FileType::CharacterDevice)
@@ -131,6 +134,7 @@ fn convert_mtree(
             path: extract_path(&item),
             properties: Properties::Special {},
             flags: FileFlags::empty(),
+            seen: Default::default(),
         }),
     })
 }

--- a/crates/paketkoll_core/src/backend/deb.rs
+++ b/crates/paketkoll_core/src/backend/deb.rs
@@ -83,7 +83,7 @@ impl Files for Debian {
         .context(format!("Failed to parse {}", STATUS_PATH))?;
 
         log::debug!(target: "paketkoll_core::backend::deb", "Merging packages files into one map");
-        let merged = DashMap::new();
+        let merged = DashMap::with_hasher(ahash::RandomState::new());
         packages_files.into_par_iter().for_each(|files| {
             merge_deb_fileentries(&merged, files, &diversions);
         });
@@ -110,7 +110,7 @@ impl Files for Debian {
 }
 
 fn merge_deb_fileentries(
-    acc: &DashMap<PathBuf, FileEntry>,
+    acc: &DashMap<PathBuf, FileEntry, ahash::RandomState>,
     files: Vec<FileEntry>,
     diversions: &divert::Diversions,
 ) {

--- a/crates/paketkoll_core/src/backend/deb/parsers.rs
+++ b/crates/paketkoll_core/src/backend/deb/parsers.rs
@@ -17,11 +17,22 @@ pub(super) fn parse_paths(
     let lines: anyhow::Result<Vec<_>> = input
         .byte_lines()
         .map(|e| match e {
+            Ok(inner) if inner.as_slice() == b"/." => {
+                // Adjust path of root directory
+                Ok(FileEntry {
+                    package: Some(package),
+                    path: "/".into(),
+                    properties: Properties::Unknown,
+                    flags: FileFlags::empty(),
+                    seen: Default::default(),
+                })
+            }
             Ok(inner) => Ok(FileEntry {
                 package: Some(package),
                 path: inner.into_path_buf().context("Failed to convert")?,
                 properties: Properties::Unknown,
                 flags: FileFlags::empty(),
+                seen: Default::default(),
             }),
             Err(err) => Err(err).context("Failed to parse"),
         })
@@ -53,6 +64,7 @@ pub(super) fn parse_md5sums(
                         checksum: Checksum::Md5(checksum),
                     }),
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 })
             }
             Err(err) => Err(err).context("Failed to parse"),
@@ -119,6 +131,7 @@ pub(super) fn parse_status(
                         checksum: Checksum::Md5(checksum),
                     }),
                     flags: FileFlags::CONFIG,
+                    seen: Default::default(),
                 })
             } else {
                 state = StatusParsingState::InPackage(pkg)
@@ -163,24 +176,28 @@ mod tests {
                     path: "/usr/share/doc/libc6/README".into(),
                     properties: Properties::Unknown,
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(package_ref),
                     path: "/usr/share/doc/libc6/changelog.Debian.gz".into(),
                     properties: Properties::Unknown,
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(package_ref),
                     path: "/usr/share/doc/libc6/copyright".into(),
                     properties: Properties::Unknown,
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(package_ref),
                     path: "/usr/share/doc/libc6/NEWS.gz".into(),
                     properties: Properties::Unknown,
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
             ]
         );
@@ -212,6 +229,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(package_ref),
@@ -225,6 +243,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(package_ref),
@@ -238,6 +257,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(package_ref),
@@ -251,6 +271,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::empty(),
+                    seen: Default::default(),
                 },
             ]
         );
@@ -299,6 +320,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::CONFIG,
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(PackageRef(interner.get_or_intern("libc6"))),
@@ -312,6 +334,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::CONFIG,
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(PackageRef(interner.get_or_intern("libc6"))),
@@ -325,6 +348,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::CONFIG,
+                    seen: Default::default(),
                 },
                 FileEntry {
                     package: Some(PackageRef(interner.get_or_intern("libc6"))),
@@ -338,6 +362,7 @@ mod tests {
                         )
                     }),
                     flags: FileFlags::CONFIG,
+                    seen: Default::default(),
                 },
             ]
         );

--- a/crates/paketkoll_core/src/backend/filesystem.rs
+++ b/crates/paketkoll_core/src/backend/filesystem.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    config::{CheckConfiguration, ConfigFiles},
+    config::{CommonConfiguration, ConfigFiles},
     types::{Directory, FileFlags, Properties, RegularFile, RegularFileBasic, Symlink},
 };
 
@@ -20,7 +20,7 @@ use anyhow::{Context, Result};
 const MODE_MASK: u32 = 0o7777;
 
 /// Determine if a given file should be processed
-fn should_process(file: &FileEntry, config: &CheckConfiguration) -> bool {
+fn should_process(file: &FileEntry, config: &CommonConfiguration) -> bool {
     match (config.config_files, file.flags.contains(FileFlags::CONFIG)) {
         (ConfigFiles::Include, _) | (ConfigFiles::Only, true) | (ConfigFiles::Exclude, false) => {
             true
@@ -30,7 +30,7 @@ fn should_process(file: &FileEntry, config: &CheckConfiguration) -> bool {
 }
 
 /// Check a single file entry from a package database against the file system
-pub(crate) fn check_file(file: &FileEntry, config: &CheckConfiguration) -> Result<Option<Issue>> {
+pub(crate) fn check_file(file: &FileEntry, config: &CommonConfiguration) -> Result<Option<Issue>> {
     let mut issues = IssueVec::new();
     match std::fs::symlink_metadata(&file.path) {
         Ok(metadata) => match &file.properties {
@@ -138,7 +138,7 @@ pub(crate) fn check_file(file: &FileEntry, config: &CheckConfiguration) -> Resul
 /// Check the contents of a regular file against the expected values
 fn check_contents(
     issues: &mut IssueVec,
-    config: &CheckConfiguration,
+    config: &CommonConfiguration,
     path: &PathBuf,
     actual_metadata: &std::fs::Metadata,
     expected_mtime: Option<&std::time::SystemTime>,

--- a/crates/paketkoll_core/src/types.rs
+++ b/crates/paketkoll_core/src/types.rs
@@ -8,7 +8,7 @@ pub(crate) use files::{
     Checksum, Directory, FileEntry, FileFlags, Gid, Mode, Properties, RegularFile,
     RegularFileBasic, Symlink, Uid,
 };
-pub(crate) use issue::{Issue, IssueKind, IssueVec};
+pub use issue::{Issue, IssueKind, IssueVec, PackageIssue};
 
 pub(crate) use package::InstallReason;
 pub use package::PackageInterner;

--- a/crates/paketkoll_core/src/types/issue.rs
+++ b/crates/paketkoll_core/src/types/issue.rs
@@ -11,6 +11,9 @@ use super::{Gid, Mode, Uid};
 /// Optimised for almost always being empty or having at most one item.
 pub type IssueVec = SmallVec<[IssueKind; 1]>;
 
+/// A package reference and an associated issue
+pub type PackageIssue = (Option<super::PackageRef>, Issue);
+
 /// A found difference between the file system and the package database
 #[derive(Debug)]
 pub struct Issue {
@@ -43,6 +46,8 @@ impl Issue {
 pub enum IssueKind {
     /// Missing entity from file system
     Missing,
+    /// Extra unexpected entity on file system
+    Unexpected,
     /// Failed to check for (or check contents of) entity due to permissions
     PermissionDenied,
     /// Type of entity was not as expected (e.g. file vs symlink)
@@ -68,7 +73,8 @@ pub enum IssueKind {
 impl std::fmt::Display for IssueKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            IssueKind::Missing => write!(f, "missing file/directory/...")?,
+            IssueKind::Missing => write!(f, "missing or inaccessible file/directory/...")?,
+            IssueKind::Unexpected => write!(f, "unexpected file")?,
             IssueKind::PermissionDenied => write!(f, "read error (Permission denied)")?,
             IssueKind::TypeIncorrect => write!(f, "type mismatch")?,
             IssueKind::SizeIncorrect => write!(f, "size mismatch")?,


### PR DESCRIPTION
TODO:

* [x] Benchmark & optimise on Debian
* [X] ~~Post-processing for Debian (find implied directories etc?)~~: Not very useful (still can't symlink/dir apart) and adds complexity
* [x] Make CLI UI reasonable
* [X] Detect missing files
* [X] ~~Missing files vs IO errors~~: No viable fix for permissions denied on parent directory
* [x] Canonical paths (a problem on Debian mostly): This could be faster if we reimplemented `realpath` from libc with memoization (due to larger number related lookups). Probably not going to happen.