### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash",
  "camino",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahash",
  "camino",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_hwinfo"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "ahash",
  "eyre",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_script"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "ahash",
  "camino",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_types"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "camino",
  "compact_str",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_utils"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "camino",
  "compact_str",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "mtree2"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bitflags 2.6.0",
  "faster-hex",
@@ -1731,7 +1731,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "paketkoll"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "clap",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_cache"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ahash",
  "cached",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_core"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "ahash",
  "ar",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "bitflags 2.6.0",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_utils"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "eyre",
  "paketkoll_types",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "systemd_tmpfiles"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64-simd",
  "bitflags 2.6.0",

--- a/crates/konfigkoll/CHANGELOG.md
+++ b/crates/konfigkoll/CHANGELOG.md
@@ -8,6 +8,31 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.8] - 2024-09-19
+
+### 🐛 Bug fixes
+
+- Fix handling of comment instructions in apply
+
+### 🩺 Diagnostics & output formatting
+
+- Make ID update less chatty (info isn't usually relevant)
+- Improve error message when failing to delete non-empty directory
+
+### 🧪 Testing
+
+- Add integration tests based on containers
+
+### ⚙️ Other stuff
+
+- Fix and enable various clippy lints
+- Change to some functions to const
+- Enable clippy::ignored_unit_patterns
+- Add some must_use as suggested by clippy
+- Enable clippy::manual_let_else
+- Fix some cases of clippy::trivially-copy-pass-by-ref
+- Enable clippy::use_self
+
 ## [0.1.7] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/konfigkoll/Cargo.toml
+++ b/crates/konfigkoll/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "konfigkoll"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.7"
+version = "0.1.8"
 
 [[bin]]
 name = "konfigkoll"
@@ -46,14 +46,14 @@ directories.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_core = { version = "0.4.1", path = "../konfigkoll_core" }
-konfigkoll_script = { version = "0.1.5", path = "../konfigkoll_script" }
-konfigkoll_types = { version = "0.2.1", path = "../konfigkoll_types" }
-konfigkoll_utils = { version = "0.1.4", path = "../konfigkoll_utils" }
+konfigkoll_core = { version = "0.4.2", path = "../konfigkoll_core" }
+konfigkoll_script = { version = "0.1.6", path = "../konfigkoll_script" }
+konfigkoll_types = { version = "0.2.2", path = "../konfigkoll_types" }
+konfigkoll_utils = { version = "0.1.5", path = "../konfigkoll_utils" }
 ouroboros.workspace = true
-paketkoll_cache = { version = "0.2.4", path = "../paketkoll_cache" }
-paketkoll_core = { version = "0.5.5", path = "../paketkoll_core" }
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
+paketkoll_cache = { version = "0.2.5", path = "../paketkoll_cache" }
+paketkoll_core = { version = "0.5.6", path = "../paketkoll_core" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 rayon.workspace = true
 rune = { workspace = true, features = ["cli"] }
 tokio.workspace = true

--- a/crates/konfigkoll_core/CHANGELOG.md
+++ b/crates/konfigkoll_core/CHANGELOG.md
@@ -8,6 +8,26 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.4.2] - 2024-09-19
+
+### 🐛 Bug fixes
+
+- Fix handling of comment instructions in apply
+
+### 🩺 Diagnostics & output formatting
+
+- Improve error message when failing to delete non-empty directory
+
+### 🧪 Testing
+
+- Add integration tests based on containers
+
+### ⚙️ Other stuff
+
+- Enable clippy::ignored_unit_patterns
+- Fix and enable various clippy lints
+- Enable clippy::use_self
+
 ## [0.4.1] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/konfigkoll_core/Cargo.toml
+++ b/crates/konfigkoll_core/Cargo.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 name = "konfigkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 ahash.workspace = true
@@ -18,11 +18,11 @@ duct.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_types = { version = "0.2.1", path = "../konfigkoll_types" }
+konfigkoll_types = { version = "0.2.2", path = "../konfigkoll_types" }
 libc.workspace = true
 nix = { workspace = true, features = ["user"] }
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.5", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.6", path = "../paketkoll_utils" }
 parking_lot.workspace = true
 rayon.workspace = true
 smallvec.workspace = true

--- a/crates/konfigkoll_hwinfo/CHANGELOG.md
+++ b/crates/konfigkoll_hwinfo/CHANGELOG.md
@@ -8,6 +8,13 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.5] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Enable clippy::ignored_unit_patterns
+- Fix and enable various clippy lints
+
 ## [0.1.4] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/konfigkoll_hwinfo/Cargo.toml
+++ b/crates/konfigkoll_hwinfo/Cargo.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 name = "konfigkoll_hwinfo"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.4"
+version = "0.1.5"
 
 [features]
 rune = ["dep:rune"]

--- a/crates/konfigkoll_script/CHANGELOG.md
+++ b/crates/konfigkoll_script/CHANGELOG.md
@@ -8,6 +8,22 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.6] - 2024-09-19
+
+### 🩺 Diagnostics & output formatting
+
+- Make ID update less chatty (info isn't usually relevant)
+
+### ⚙️ Other stuff
+
+- Change to some functions to const
+- Enable clippy::ignored_unit_patterns
+- Add some must_use as suggested by clippy
+- Enable clippy::manual_let_else
+- Fix and enable various clippy lints
+- Fix some cases of clippy::trivially-copy-pass-by-ref
+- Enable clippy::use_self
+
 ## [0.1.5] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/konfigkoll_script/Cargo.toml
+++ b/crates/konfigkoll_script/Cargo.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 name = "konfigkoll_script"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 ahash.workspace = true
@@ -16,12 +16,12 @@ eyre.workspace = true
 glob.workspace = true
 globset.workspace = true
 itertools.workspace = true
-konfigkoll_hwinfo = { version = "0.1.4", path = "../konfigkoll_hwinfo", features = [
+konfigkoll_hwinfo = { version = "0.1.5", path = "../konfigkoll_hwinfo", features = [
     "rune",
 ] }
-konfigkoll_types = { version = "0.2.1", path = "../konfigkoll_types" }
-konfigkoll_utils = { version = "0.1.4", path = "../konfigkoll_utils" }
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
+konfigkoll_types = { version = "0.2.2", path = "../konfigkoll_types" }
+konfigkoll_utils = { version = "0.1.5", path = "../konfigkoll_utils" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 parking_lot.workspace = true
 regex.workspace = true
 rune-modules.workspace = true

--- a/crates/konfigkoll_types/CHANGELOG.md
+++ b/crates/konfigkoll_types/CHANGELOG.md
@@ -8,6 +8,13 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.2] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Change to some functions to const
+- Enable clippy::use_self
+
 ## [0.2.1] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/konfigkoll_types/Cargo.toml
+++ b/crates/konfigkoll_types/Cargo.toml
@@ -5,15 +5,15 @@ license = "MPL-2.0"
 name = "konfigkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true
 either.workspace = true
 eyre.workspace = true
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.5", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.6", path = "../paketkoll_utils" }
 strum.workspace = true
 
 [lints]

--- a/crates/konfigkoll_utils/CHANGELOG.md
+++ b/crates/konfigkoll_utils/CHANGELOG.md
@@ -8,6 +8,13 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.5] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Fix and enable various clippy lints
+- Enable clippy::use_self
+
 ## [0.1.4] - 2024-09-06
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_utils/Cargo.toml
+++ b/crates/konfigkoll_utils/Cargo.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 name = "konfigkoll_utils"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.4"
+version = "0.1.5"
 
 [dependencies]
 camino.workspace = true

--- a/crates/mtree2/CHANGELOG.md
+++ b/crates/mtree2/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.6.7] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Change to some functions to const
+- Enable clippy::manual_let_else
+- Fix and enable various clippy lints
+- Fix some cases of clippy::trivially-copy-pass-by-ref
+- Enable clippy::use_self
+
 ## [0.6.6] - 2024-09-06
 
 ### ⚡ Performance improvements

--- a/crates/mtree2/Cargo.toml
+++ b/crates/mtree2/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 OR MIT"
 name = "mtree2"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
-version = "0.6.6"
+version = "0.6.7"
 
 [dependencies]
 bitflags.workspace = true

--- a/crates/paketkoll/CHANGELOG.md
+++ b/crates/paketkoll/CHANGELOG.md
@@ -8,6 +8,13 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.3.6] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Fix some cases of clippy::trivially-copy-pass-by-ref
+- Enable clippy::use_self
+
 ## [0.3.5] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/paketkoll/Cargo.toml
+++ b/crates/paketkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "paketkoll"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.3.5"
+version = "0.3.6"
 
 [features]
 # Default features
@@ -36,8 +36,8 @@ color-eyre.workspace = true
 compact_str.workspace = true
 eyre.workspace = true
 os_info.workspace = true
-paketkoll_core = { version = "0.5.5", path = "../paketkoll_core" }
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
+paketkoll_core = { version = "0.5.6", path = "../paketkoll_core" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 proc-exit.workspace = true
 rayon.workspace = true
 serde = { workspace = true, optional = true }

--- a/crates/paketkoll_cache/CHANGELOG.md
+++ b/crates/paketkoll_cache/CHANGELOG.md
@@ -8,6 +8,13 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.5] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Change to some functions to const
+- Fix and enable various clippy lints
+
 ## [0.2.4] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/paketkoll_cache/Cargo.toml
+++ b/crates/paketkoll_cache/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_cache"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.4"
+version = "0.2.5"
 
 [dependencies]
 ahash.workspace = true
@@ -15,7 +15,7 @@ cached.workspace = true
 compact_str.workspace = true
 dashmap.workspace = true
 eyre.workspace = true
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 serde.workspace = true
 smallvec.workspace = true
 tracing.workspace = true

--- a/crates/paketkoll_core/CHANGELOG.md
+++ b/crates/paketkoll_core/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.6] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Change to some functions to const
+- Enable clippy::manual_let_else
+- Fix and enable various clippy lints
+- Fix some cases of clippy::trivially-copy-pass-by-ref
+- Enable clippy::use_self
+
 ## [0.5.5] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/paketkoll_core/Cargo.toml
+++ b/crates/paketkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.5.5"
+version = "0.5.6"
 
     [package.metadata.docs.rs]
     default-target = "x86_64-unknown-linux-gnu"
@@ -70,11 +70,11 @@ glob.workspace = true
 ignore.workspace = true
 libc.workspace = true
 md-5 = { workspace = true, optional = true }
-mtree2 = { version = "0.6.6", path = "../mtree2", optional = true }
+mtree2 = { version = "0.6.7", path = "../mtree2", optional = true }
 nix = { workspace = true, features = ["user"], optional = true }
 num_cpus.workspace = true
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.5", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.6", path = "../paketkoll_utils" }
 parking_lot.workspace = true
 phf.workspace = true
 rayon.workspace = true
@@ -84,7 +84,7 @@ rust-ini = { workspace = true, optional = true }
 scopeguard.workspace = true
 smallvec.workspace = true
 strum.workspace = true
-systemd_tmpfiles = { version = "0.2.0", path = "../systemd_tmpfiles", optional = true }
+systemd_tmpfiles = { version = "0.2.1", path = "../systemd_tmpfiles", optional = true }
 tar.workspace = true
 tracing.workspace = true
 xz2 = { workspace = true, optional = true }

--- a/crates/paketkoll_types/CHANGELOG.md
+++ b/crates/paketkoll_types/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.1] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Change to some functions to const
+- Add some must_use as suggested by clippy
+- Fix and enable various clippy lints
+- Fix some cases of clippy::trivially-copy-pass-by-ref
+- Enable clippy::use_self
+
 ## [0.2.0] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/paketkoll_types/Cargo.toml
+++ b/crates/paketkoll_types/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 ahash.workspace = true

--- a/crates/paketkoll_utils/CHANGELOG.md
+++ b/crates/paketkoll_utils/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.6] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Updated the following local packages: paketkoll_types
+
 ## [0.1.5] - 2024-09-06
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/paketkoll_utils/Cargo.toml
+++ b/crates/paketkoll_utils/Cargo.toml
@@ -5,11 +5,11 @@ license = "MPL-2.0"
 name = "paketkoll_utils"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 eyre.workspace = true
-paketkoll_types = { version = "0.2.0", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 ring.workspace = true
 
 [lints]

--- a/crates/systemd_tmpfiles/CHANGELOG.md
+++ b/crates/systemd_tmpfiles/CHANGELOG.md
@@ -8,6 +8,15 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.1] - 2024-09-19
+
+### ⚙️ Other stuff
+
+- Enable additional rustc and clippy lints
+- Enable clippy::ignored_unit_patterns
+- Fix and enable various clippy lints
+- Enable clippy::use_self
+
 ## [0.2.0] - 2024-09-06
 
 ### ⚙️ Other stuff

--- a/crates/systemd_tmpfiles/Cargo.toml
+++ b/crates/systemd_tmpfiles/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "systemd_tmpfiles"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.0"
+version = "0.2.1"
 
     [package.metadata.docs.rs]
     default-target = "x86_64-unknown-linux-gnu"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -31,8 +31,8 @@ clap_complete.workspace = true
 clap_mangen.workspace = true
 color-eyre.workspace = true
 eyre.workspace = true
-konfigkoll = { version = "0.1.7", path = "../konfigkoll" }
-paketkoll = { version = "0.3.5", path = "../paketkoll" }
+konfigkoll = { version = "0.1.8", path = "../konfigkoll" }
+paketkoll = { version = "0.3.6", path = "../paketkoll" }
 tracing-subscriber.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## 🤖 New release
* `konfigkoll`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `konfigkoll_core`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `konfigkoll_types`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `paketkoll_types`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `konfigkoll_script`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `konfigkoll_hwinfo`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `konfigkoll_utils`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `paketkoll_cache`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `paketkoll_core`: 0.5.5 -> 0.5.6 (✓ API compatible changes)
* `mtree2`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `systemd_tmpfiles`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `paketkoll`: 0.3.5 -> 0.3.6 (✓ API compatible changes)
* `paketkoll_utils`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `konfigkoll`
<blockquote>

## [0.1.8] - 2024-09-19

### 🐛 Bug fixes

- Fix handling of comment instructions in apply

### 🩺 Diagnostics & output formatting

- Make ID update less chatty (info isn't usually relevant)
- Improve error message when failing to delete non-empty directory

### 🧪 Testing

- Add integration tests based on containers

### ⚙️ Other stuff

- Fix and enable various clippy lints
- Change to some functions to const
- Enable clippy::ignored_unit_patterns
- Add some must_use as suggested by clippy
- Enable clippy::manual_let_else
- Fix some cases of clippy::trivially-copy-pass-by-ref
- Enable clippy::use_self
</blockquote>

## `konfigkoll_core`
<blockquote>

## [0.4.2] - 2024-09-19

### 🐛 Bug fixes

- Fix handling of comment instructions in apply

### 🩺 Diagnostics & output formatting

- Improve error message when failing to delete non-empty directory

### 🧪 Testing

- Add integration tests based on containers

### ⚙️ Other stuff

- Enable clippy::ignored_unit_patterns
- Fix and enable various clippy lints
- Enable clippy::use_self
</blockquote>

## `konfigkoll_types`
<blockquote>

## [0.2.2] - 2024-09-19

### ⚙️ Other stuff

- Change to some functions to const
- Enable clippy::use_self
</blockquote>

## `paketkoll_types`
<blockquote>

## [0.2.1] - 2024-09-19

### ⚙️ Other stuff

- Change to some functions to const
- Add some must_use as suggested by clippy
- Fix and enable various clippy lints
- Fix some cases of clippy::trivially-copy-pass-by-ref
- Enable clippy::use_self
</blockquote>

## `konfigkoll_script`
<blockquote>

## [0.1.6] - 2024-09-19

### 🩺 Diagnostics & output formatting

- Make ID update less chatty (info isn't usually relevant)

### ⚙️ Other stuff

- Change to some functions to const
- Enable clippy::ignored_unit_patterns
- Add some must_use as suggested by clippy
- Enable clippy::manual_let_else
- Fix and enable various clippy lints
- Fix some cases of clippy::trivially-copy-pass-by-ref
- Enable clippy::use_self
</blockquote>

## `konfigkoll_hwinfo`
<blockquote>

## [0.1.5] - 2024-09-19

### ⚙️ Other stuff

- Enable clippy::ignored_unit_patterns
- Fix and enable various clippy lints
</blockquote>

## `konfigkoll_utils`
<blockquote>

## [0.1.5] - 2024-09-19

### ⚙️ Other stuff

- Fix and enable various clippy lints
- Enable clippy::use_self
</blockquote>

## `paketkoll_cache`
<blockquote>

## [0.2.5] - 2024-09-19

### ⚙️ Other stuff

- Change to some functions to const
- Fix and enable various clippy lints
</blockquote>

## `paketkoll_core`
<blockquote>

## [0.5.6] - 2024-09-19

### ⚙️ Other stuff

- Change to some functions to const
- Enable clippy::manual_let_else
- Fix and enable various clippy lints
- Fix some cases of clippy::trivially-copy-pass-by-ref
- Enable clippy::use_self
</blockquote>

## `mtree2`
<blockquote>

## [0.6.7] - 2024-09-19

### ⚙️ Other stuff

- Change to some functions to const
- Enable clippy::manual_let_else
- Fix and enable various clippy lints
- Fix some cases of clippy::trivially-copy-pass-by-ref
- Enable clippy::use_self
</blockquote>

## `systemd_tmpfiles`
<blockquote>

## [0.2.1] - 2024-09-19

### ⚙️ Other stuff

- Enable additional rustc and clippy lints
- Enable clippy::ignored_unit_patterns
- Fix and enable various clippy lints
- Enable clippy::use_self
</blockquote>

## `paketkoll`
<blockquote>

## [0.3.6] - 2024-09-19

### ⚙️ Other stuff

- Fix some cases of clippy::trivially-copy-pass-by-ref
- Enable clippy::use_self
</blockquote>

## `paketkoll_utils`
<blockquote>

## [0.1.6] - 2024-09-19

### ⚙️ Other stuff

- Updated the following local packages: paketkoll_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).