### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ahash",
  "camino",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "camino",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_hwinfo"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "ahash",
  "eyre",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_script"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "camino",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_types"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "camino",
  "compact_str",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_utils"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "compact_str",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "mtree2"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "bitflags 2.6.0",
  "faster-hex",
@@ -1731,7 +1731,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "paketkoll"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "ahash",
  "clap",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_cache"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "ahash",
  "cached",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_core"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "ahash",
  "ar",

--- a/crates/konfigkoll/CHANGELOG.md
+++ b/crates/konfigkoll/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.9] - 2024-09-20
+
+### 🚀 Features
+
+- Improve diff view when restoring to package manager state (fixes [#91](https://github.com/VorpalBlade/paketkoll/pull/91))
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.1.8] - 2024-09-19
 
 ### 🐛 Bug fixes

--- a/crates/konfigkoll/Cargo.toml
+++ b/crates/konfigkoll/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "konfigkoll"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.8"
+version = "0.1.9"
 
 [[bin]]
 name = "konfigkoll"
@@ -46,13 +46,13 @@ directories.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_core = { version = "0.4.2", path = "../konfigkoll_core" }
-konfigkoll_script = { version = "0.1.6", path = "../konfigkoll_script" }
-konfigkoll_types = { version = "0.2.2", path = "../konfigkoll_types" }
-konfigkoll_utils = { version = "0.1.5", path = "../konfigkoll_utils" }
+konfigkoll_core = { version = "0.5.0", path = "../konfigkoll_core" }
+konfigkoll_script = { version = "0.1.7", path = "../konfigkoll_script" }
+konfigkoll_types = { version = "0.2.3", path = "../konfigkoll_types" }
+konfigkoll_utils = { version = "0.1.6", path = "../konfigkoll_utils" }
 ouroboros.workspace = true
-paketkoll_cache = { version = "0.2.5", path = "../paketkoll_cache" }
-paketkoll_core = { version = "0.5.6", path = "../paketkoll_core" }
+paketkoll_cache = { version = "0.2.6", path = "../paketkoll_cache" }
+paketkoll_core = { version = "0.5.7", path = "../paketkoll_core" }
 paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 rayon.workspace = true
 rune = { workspace = true, features = ["cli"] }

--- a/crates/konfigkoll_core/CHANGELOG.md
+++ b/crates/konfigkoll_core/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.0] - 2024-09-20
+
+### 🚀 Features
+
+- Improve diff view when restoring to package manager state (fixes [#91](https://github.com/VorpalBlade/paketkoll/pull/91))
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.4.2] - 2024-09-19
 
 ### 🐛 Bug fixes

--- a/crates/konfigkoll_core/Cargo.toml
+++ b/crates/konfigkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.4.2"
+version = "0.5.0"
 
 [dependencies]
 ahash.workspace = true
@@ -20,7 +20,7 @@ duct.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_types = { version = "0.2.2", path = "../konfigkoll_types" }
+konfigkoll_types = { version = "0.2.3", path = "../konfigkoll_types" }
 libc.workspace = true
 nix = { workspace = true, features = ["user"] }
 paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }

--- a/crates/konfigkoll_hwinfo/CHANGELOG.md
+++ b/crates/konfigkoll_hwinfo/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.6] - 2024-09-20
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.1.5] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_hwinfo/Cargo.toml
+++ b/crates/konfigkoll_hwinfo/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_hwinfo"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.5"
+version = "0.1.6"
 
 [features]
 rune = ["dep:rune"]

--- a/crates/konfigkoll_script/CHANGELOG.md
+++ b/crates/konfigkoll_script/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.7] - 2024-09-20
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.1.6] - 2024-09-19
 
 ### 🩺 Diagnostics & output formatting

--- a/crates/konfigkoll_script/Cargo.toml
+++ b/crates/konfigkoll_script/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_script"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies]
 ahash.workspace = true
@@ -18,11 +18,11 @@ eyre.workspace = true
 glob.workspace = true
 globset.workspace = true
 itertools.workspace = true
-konfigkoll_hwinfo = { version = "0.1.5", path = "../konfigkoll_hwinfo", features = [
+konfigkoll_hwinfo = { version = "0.1.6", path = "../konfigkoll_hwinfo", features = [
     "rune",
 ] }
-konfigkoll_types = { version = "0.2.2", path = "../konfigkoll_types" }
-konfigkoll_utils = { version = "0.1.5", path = "../konfigkoll_utils" }
+konfigkoll_types = { version = "0.2.3", path = "../konfigkoll_types" }
+konfigkoll_utils = { version = "0.1.6", path = "../konfigkoll_utils" }
 paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 parking_lot.workspace = true
 regex.workspace = true

--- a/crates/konfigkoll_types/CHANGELOG.md
+++ b/crates/konfigkoll_types/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.3] - 2024-09-20
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.2.2] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_types/Cargo.toml
+++ b/crates/konfigkoll_types/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 name = "konfigkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies]
 camino.workspace = true

--- a/crates/konfigkoll_utils/CHANGELOG.md
+++ b/crates/konfigkoll_utils/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.6] - 2024-09-20
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.1.5] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_utils/Cargo.toml
+++ b/crates/konfigkoll_utils/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 name = "konfigkoll_utils"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 camino.workspace = true

--- a/crates/mtree2/CHANGELOG.md
+++ b/crates/mtree2/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.6.8] - 2024-09-20
+
+### ⚙️ Other stuff
+
+- Add crates.io package keywords & categories
+
 ## [0.6.7] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/mtree2/Cargo.toml
+++ b/crates/mtree2/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 name = "mtree2"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
-version = "0.6.7"
+version = "0.6.8"
 
 [dependencies]
 bitflags.workspace = true

--- a/crates/paketkoll/CHANGELOG.md
+++ b/crates/paketkoll/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.3.7] - 2024-09-20
+
+### ⚙️ Other stuff
+
+- Updated the following local packages: paketkoll_core
+
 ## [0.3.6] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll/Cargo.toml
+++ b/crates/paketkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "paketkoll"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.3.6"
+version = "0.3.7"
 
 [features]
 # Default features
@@ -36,7 +36,7 @@ color-eyre.workspace = true
 compact_str.workspace = true
 eyre.workspace = true
 os_info.workspace = true
-paketkoll_core = { version = "0.5.6", path = "../paketkoll_core" }
+paketkoll_core = { version = "0.5.7", path = "../paketkoll_core" }
 paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
 proc-exit.workspace = true
 rayon.workspace = true

--- a/crates/paketkoll_cache/CHANGELOG.md
+++ b/crates/paketkoll_cache/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.6] - 2024-09-20
+
+### 🐛 Bug fixes
+
+- Do not wrap the error in the caching layer, it breaks the systemd path fallback logic
+
 ## [0.2.5] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_cache/Cargo.toml
+++ b/crates/paketkoll_cache/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_cache"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.5"
+version = "0.2.6"
 
 [dependencies]
 ahash.workspace = true

--- a/crates/paketkoll_core/CHANGELOG.md
+++ b/crates/paketkoll_core/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.7] - 2024-09-20
+
+### 🚀 Features
+
+- Support uncompressed tar files in deb packages
+
 ## [0.5.6] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_core/Cargo.toml
+++ b/crates/paketkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.5.6"
+version = "0.5.7"
 
     [package.metadata.docs.rs]
     default-target = "x86_64-unknown-linux-gnu"
@@ -70,7 +70,7 @@ glob.workspace = true
 ignore.workspace = true
 libc.workspace = true
 md-5 = { workspace = true, optional = true }
-mtree2 = { version = "0.6.7", path = "../mtree2", optional = true }
+mtree2 = { version = "0.6.8", path = "../mtree2", optional = true }
 nix = { workspace = true, features = ["user"], optional = true }
 num_cpus.workspace = true
 paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -31,8 +31,8 @@ clap_complete.workspace = true
 clap_mangen.workspace = true
 color-eyre.workspace = true
 eyre.workspace = true
-konfigkoll = { version = "0.1.8", path = "../konfigkoll" }
-paketkoll = { version = "0.3.6", path = "../paketkoll" }
+konfigkoll = { version = "0.1.9", path = "../konfigkoll" }
+paketkoll = { version = "0.3.7", path = "../paketkoll" }
 tracing-subscriber.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
## 🤖 New release
* `konfigkoll`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `konfigkoll_core`: 0.4.2 -> 0.5.0 (⚠️ API breaking changes)
* `konfigkoll_types`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `konfigkoll_script`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `konfigkoll_hwinfo`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `konfigkoll_utils`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `paketkoll_cache`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `paketkoll_core`: 0.5.6 -> 0.5.7 (✓ API compatible changes)
* `mtree2`: 0.6.7 -> 0.6.8 (✓ API compatible changes)
* `paketkoll`: 0.3.6 -> 0.3.7

### ⚠️ `konfigkoll_core` breaking changes

```
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type InteractiveApplicator is no longer UnwindSafe, in /tmp/.tmptVvxt1/paketkoll/crates/konfigkoll_core/src/apply.rs:356
  type InteractiveApplicator is no longer RefUnwindSafe, in /tmp/.tmptVvxt1/paketkoll/crates/konfigkoll_core/src/apply.rs:356

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/function_parameter_count_changed.ron

Failed in:
  konfigkoll_core::diff::show_fs_instr_diff now takes 6 parameters instead of 3, in /tmp/.tmptVvxt1/paketkoll/crates/konfigkoll_core/src/diff.rs:31

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/method_parameter_count_changed.ron

Failed in:
  konfigkoll_core::apply::InteractiveApplicator::new now takes 6 parameters instead of 3, in /tmp/.tmptVvxt1/paketkoll/crates/konfigkoll_core/src/apply.rs:369
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `konfigkoll`
<blockquote>

## [0.1.9] - 2024-09-20

### 🚀 Features

- Improve diff view when restoring to package manager state (fixes [#91](https://github.com/VorpalBlade/paketkoll/pull/91))

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `konfigkoll_core`
<blockquote>

## [0.5.0] - 2024-09-20

### 🚀 Features

- Improve diff view when restoring to package manager state (fixes [#91](https://github.com/VorpalBlade/paketkoll/pull/91))

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `konfigkoll_types`
<blockquote>

## [0.2.3] - 2024-09-20

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `konfigkoll_script`
<blockquote>

## [0.1.7] - 2024-09-20

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `konfigkoll_hwinfo`
<blockquote>

## [0.1.6] - 2024-09-20

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `konfigkoll_utils`
<blockquote>

## [0.1.6] - 2024-09-20

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `paketkoll_cache`
<blockquote>

## [0.2.6] - 2024-09-20

### 🐛 Bug fixes

- Do not wrap the error in the caching layer, it breaks the systemd path fallback logic
</blockquote>

## `paketkoll_core`
<blockquote>

## [0.5.7] - 2024-09-20

### 🚀 Features

- Support uncompressed tar files in deb packages
</blockquote>

## `mtree2`
<blockquote>

## [0.6.8] - 2024-09-20

### ⚙️ Other stuff

- Add crates.io package keywords & categories
</blockquote>

## `paketkoll`
<blockquote>

## [0.3.7] - 2024-09-20

### ⚙️ Other stuff

- Updated the following local packages: paketkoll_core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).