### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ahash",
  "camino",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "camino",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_hwinfo"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "eyre",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_script"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_types"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "camino",
  "compact_str",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_utils"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "camino",
  "compact_str",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mtree2"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bitflags 2.6.0",
  "faster-hex",
@@ -1902,7 +1902,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "paketkoll"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "clap",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_cache"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ahash",
  "cached",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_core"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "ahash",
  "ar",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_types"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ahash",
  "bitflags 2.6.0",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_utils"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "eyre",
  "paketkoll_types",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "systemd_tmpfiles"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64-simd",
  "bitflags 2.6.0",

--- a/crates/konfigkoll/CHANGELOG.md
+++ b/crates/konfigkoll/CHANGELOG.md
@@ -8,6 +8,24 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.10] - 2024-12-16
+
+### 🚀 Features
+
+- Add support for locked users in sysusers parser (needed to work on newer systemd)
+
+### 🐛 Bug fixes
+
+- Fix new clippy warnings on Rust 1.82
+
+### 🩺 Diagnostics & output formatting
+
+- Improve parse errors from sysusers
+
+### ⚙️ Other stuff
+
+- Use workspace hack with cargo-hakari for faster dev builds
+
 ## [0.1.9] - 2024-09-20
 
 ### 🚀 Features

--- a/crates/konfigkoll/Cargo.toml
+++ b/crates/konfigkoll/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "konfigkoll"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.9"
+version = "0.1.10"
 
 [[bin]]
 name = "konfigkoll"
@@ -46,14 +46,14 @@ directories.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_core = { version = "0.5.0", path = "../konfigkoll_core" }
-konfigkoll_script = { version = "0.1.7", path = "../konfigkoll_script" }
-konfigkoll_types = { version = "0.2.3", path = "../konfigkoll_types" }
-konfigkoll_utils = { version = "0.1.6", path = "../konfigkoll_utils" }
+konfigkoll_core = { version = "0.5.1", path = "../konfigkoll_core" }
+konfigkoll_script = { version = "0.1.8", path = "../konfigkoll_script" }
+konfigkoll_types = { version = "0.2.4", path = "../konfigkoll_types" }
+konfigkoll_utils = { version = "0.1.7", path = "../konfigkoll_utils" }
 ouroboros.workspace = true
-paketkoll_cache = { version = "0.2.6", path = "../paketkoll_cache" }
-paketkoll_core = { version = "0.5.7", path = "../paketkoll_core" }
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_cache = { version = "0.2.7", path = "../paketkoll_cache" }
+paketkoll_core = { version = "0.5.8", path = "../paketkoll_core" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 rayon.workspace = true
 rune = { workspace = true, features = ["cli"] }

--- a/crates/konfigkoll_core/CHANGELOG.md
+++ b/crates/konfigkoll_core/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.1] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.5.0] - 2024-09-20
 
 ### 🚀 Features

--- a/crates/konfigkoll_core/Cargo.toml
+++ b/crates/konfigkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 ahash.workspace = true
@@ -20,11 +20,11 @@ duct.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_types = { version = "0.2.3", path = "../konfigkoll_types" }
+konfigkoll_types = { version = "0.2.4", path = "../konfigkoll_types" }
 libc.workspace = true
 nix = { workspace = true, features = ["user"] }
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.6", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.7", path = "../paketkoll_utils" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 parking_lot.workspace = true
 rayon.workspace = true

--- a/crates/konfigkoll_hwinfo/CHANGELOG.md
+++ b/crates/konfigkoll_hwinfo/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.7] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.1.6] - 2024-09-20
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_hwinfo/Cargo.toml
+++ b/crates/konfigkoll_hwinfo/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_hwinfo"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.6"
+version = "0.1.7"
 
 [features]
 rune = ["dep:rune"]

--- a/crates/konfigkoll_script/CHANGELOG.md
+++ b/crates/konfigkoll_script/CHANGELOG.md
@@ -8,6 +8,21 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.8] - 2024-12-16
+
+### 🚀 Features
+
+- Add support for locked users in sysusers parser
+- Prepare workspace hack with cargo-hakari
+
+### 🐛 Bug fixes
+
+- Fix new clippy warnings on Rust 1.82
+
+### 🩺 Diagnostics & output formatting
+
+- Improve parse errors from sysusers
+
 ## [0.1.7] - 2024-09-20
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_script/Cargo.toml
+++ b/crates/konfigkoll_script/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_script"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.7"
+version = "0.1.8"
 
 [dependencies]
 ahash.workspace = true
@@ -19,12 +19,12 @@ eyre.workspace = true
 glob.workspace = true
 globset.workspace = true
 itertools.workspace = true
-konfigkoll_hwinfo = { version = "0.1.6", path = "../konfigkoll_hwinfo", features = [
+konfigkoll_hwinfo = { version = "0.1.7", path = "../konfigkoll_hwinfo", features = [
     "rune",
 ] }
-konfigkoll_types = { version = "0.2.3", path = "../konfigkoll_types" }
-konfigkoll_utils = { version = "0.1.6", path = "../konfigkoll_utils" }
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+konfigkoll_types = { version = "0.2.4", path = "../konfigkoll_types" }
+konfigkoll_utils = { version = "0.1.7", path = "../konfigkoll_utils" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 parking_lot.workspace = true
 regex.workspace = true

--- a/crates/konfigkoll_types/CHANGELOG.md
+++ b/crates/konfigkoll_types/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.4] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.2.3] - 2024-09-20
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_types/Cargo.toml
+++ b/crates/konfigkoll_types/Cargo.toml
@@ -6,15 +6,15 @@ license = "MPL-2.0"
 name = "konfigkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.3"
+version = "0.2.4"
 
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true
 either.workspace = true
 eyre.workspace = true
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.6", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.7", path = "../paketkoll_utils" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 strum.workspace = true
 

--- a/crates/konfigkoll_utils/CHANGELOG.md
+++ b/crates/konfigkoll_utils/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.7] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.1.6] - 2024-09-20
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_utils/Cargo.toml
+++ b/crates/konfigkoll_utils/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 name = "konfigkoll_utils"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies]
 camino.workspace = true

--- a/crates/mtree2/CHANGELOG.md
+++ b/crates/mtree2/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.6.9] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.6.8] - 2024-09-20
 
 ### ⚙️ Other stuff

--- a/crates/mtree2/Cargo.toml
+++ b/crates/mtree2/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 name = "mtree2"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
-version = "0.6.8"
+version = "0.6.9"
 
 [dependencies]
 bitflags.workspace = true

--- a/crates/paketkoll/CHANGELOG.md
+++ b/crates/paketkoll/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.3.8] - 2024-12-16
+
+### ⚙️ Other stuff
+
+- Use workspace hack with cargo-hakari for faster dev builds
+
 ## [0.3.7] - 2024-09-20
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll/Cargo.toml
+++ b/crates/paketkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "paketkoll"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.3.7"
+version = "0.3.8"
 
 [features]
 # Default features
@@ -36,8 +36,8 @@ color-eyre.workspace = true
 compact_str.workspace = true
 eyre.workspace = true
 os_info.workspace = true
-paketkoll_core = { version = "0.5.7", path = "../paketkoll_core" }
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_core = { version = "0.5.8", path = "../paketkoll_core" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 proc-exit.workspace = true
 rayon.workspace = true

--- a/crates/paketkoll_cache/CHANGELOG.md
+++ b/crates/paketkoll_cache/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.7] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.2.6] - 2024-09-20
 
 ### 🐛 Bug fixes

--- a/crates/paketkoll_cache/Cargo.toml
+++ b/crates/paketkoll_cache/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_cache"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.6"
+version = "0.2.7"
 
 [dependencies]
 ahash.workspace = true
@@ -15,7 +15,7 @@ cached.workspace = true
 compact_str.workspace = true
 dashmap.workspace = true
 eyre.workspace = true
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 serde.workspace = true
 smallvec.workspace = true

--- a/crates/paketkoll_core/CHANGELOG.md
+++ b/crates/paketkoll_core/CHANGELOG.md
@@ -8,6 +8,24 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.8] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
+### 🐛 Bug fixes
+
+- Fix new clippy warnings on Rust 1.82
+
+### 🩺 Diagnostics & output formatting
+
+- Better errors when package archive reading fails
+
+### ⚙️ Other stuff
+
+- Fix clippy on newer rust
+
 ## [0.5.7] - 2024-09-20
 
 ### 🚀 Features

--- a/crates/paketkoll_core/Cargo.toml
+++ b/crates/paketkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.5.7"
+version = "0.5.8"
 
     [package.metadata.docs.rs]
     default-target = "x86_64-unknown-linux-gnu"
@@ -70,11 +70,11 @@ glob.workspace = true
 ignore.workspace = true
 libc.workspace = true
 md-5 = { workspace = true, optional = true }
-mtree2 = { version = "0.6.8", path = "../mtree2", optional = true }
+mtree2 = { version = "0.6.9", path = "../mtree2", optional = true }
 nix = { workspace = true, features = ["user"], optional = true }
 num_cpus.workspace = true
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.6", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.7", path = "../paketkoll_utils" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 parking_lot.workspace = true
 phf.workspace = true
@@ -85,7 +85,7 @@ rust-ini = { workspace = true, optional = true }
 scopeguard.workspace = true
 smallvec.workspace = true
 strum.workspace = true
-systemd_tmpfiles = { version = "0.2.1", path = "../systemd_tmpfiles", optional = true }
+systemd_tmpfiles = { version = "0.2.2", path = "../systemd_tmpfiles", optional = true }
 tar.workspace = true
 tracing.workspace = true
 xz2 = { workspace = true, optional = true }

--- a/crates/paketkoll_types/CHANGELOG.md
+++ b/crates/paketkoll_types/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.2] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.2.1] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_types/Cargo.toml
+++ b/crates/paketkoll_types/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 ahash.workspace = true

--- a/crates/paketkoll_utils/CHANGELOG.md
+++ b/crates/paketkoll_utils/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.7] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
 ## [0.1.6] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_utils/Cargo.toml
+++ b/crates/paketkoll_utils/Cargo.toml
@@ -5,11 +5,11 @@ license = "MPL-2.0"
 name = "paketkoll_utils"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies]
 eyre.workspace = true
-paketkoll_types = { version = "0.2.1", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.2", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 ring.workspace = true
 

--- a/crates/systemd_tmpfiles/CHANGELOG.md
+++ b/crates/systemd_tmpfiles/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.2] - 2024-12-16
+
+### 🚀 Features
+
+- Prepare workspace hack with cargo-hakari
+
+### ⚙️ Other stuff
+
+- Fix clippy on newer rust
+
 ## [0.2.1] - 2024-09-19
 
 ### ⚙️ Other stuff

--- a/crates/systemd_tmpfiles/Cargo.toml
+++ b/crates/systemd_tmpfiles/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "systemd_tmpfiles"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.80.0"
-version = "0.2.1"
+version = "0.2.2"
 
     [package.metadata.docs.rs]
     default-target = "x86_64-unknown-linux-gnu"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -31,8 +31,8 @@ clap_complete.workspace = true
 clap_mangen.workspace = true
 color-eyre.workspace = true
 eyre.workspace = true
-konfigkoll = { version = "0.1.9", path = "../konfigkoll" }
-paketkoll = { version = "0.3.7", path = "../paketkoll" }
+konfigkoll = { version = "0.1.10", path = "../konfigkoll" }
+paketkoll = { version = "0.3.8", path = "../paketkoll" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 tracing-subscriber.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `konfigkoll`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `konfigkoll_core`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `konfigkoll_types`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `paketkoll_types`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `paketkoll_utils`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `konfigkoll_script`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `konfigkoll_hwinfo`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `konfigkoll_utils`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `paketkoll_cache`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `paketkoll_core`: 0.5.7 -> 0.5.8 (✓ API compatible changes)
* `mtree2`: 0.6.8 -> 0.6.9 (✓ API compatible changes)
* `systemd_tmpfiles`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `paketkoll`: 0.3.7 -> 0.3.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `konfigkoll`
<blockquote>

## [0.1.10] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
- Add support for locked users in sysusers parser

### 🐛 Bug fixes

- Fix new clippy warnings on Rust 1.82

### 🩺 Diagnostics & output formatting

- Improve parse errors from sysusers

### ⚙️ Other stuff

- Fix clippy on newer rust
</blockquote>

## `konfigkoll_core`
<blockquote>

## [0.5.1] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `konfigkoll_types`
<blockquote>

## [0.2.4] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `paketkoll_types`
<blockquote>

## [0.2.2] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `paketkoll_utils`
<blockquote>

## [0.1.7] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `konfigkoll_script`
<blockquote>

## [0.1.8] - 2024-12-16

### 🚀 Features

- Add support for locked users in sysusers parser
- Prepare workspace hack with cargo-hakari

### 🐛 Bug fixes

- Fix new clippy warnings on Rust 1.82

### 🩺 Diagnostics & output formatting

- Improve parse errors from sysusers
</blockquote>

## `konfigkoll_hwinfo`
<blockquote>

## [0.1.7] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `konfigkoll_utils`
<blockquote>

## [0.1.7] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `paketkoll_cache`
<blockquote>

## [0.2.7] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `paketkoll_core`
<blockquote>

## [0.5.8] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari

### 🐛 Bug fixes

- Fix new clippy warnings on Rust 1.82

### 🩺 Diagnostics & output formatting

- Better errors when package archive reading fails

### ⚙️ Other stuff

- Fix clippy on newer rust
</blockquote>

## `mtree2`
<blockquote>

## [0.6.9] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>

## `systemd_tmpfiles`
<blockquote>

## [0.2.2] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari

### ⚙️ Other stuff

- Fix clippy on newer rust
</blockquote>

## `paketkoll`
<blockquote>

## [0.3.8] - 2024-12-16

### 🚀 Features

- Prepare workspace hack with cargo-hakari
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).