### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "ahash",
  "camino",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "ahash",
  "camino",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_hwinfo"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ahash",
  "eyre",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_script"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "konfigkoll_types"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "camino",
  "compact_str",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mtree2"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "bitflags 2.9.0",
  "faster-hex",
@@ -1921,7 +1921,7 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "paketkoll"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "ahash",
  "clap",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_cache"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ahash",
  "cached",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_core"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "ahash",
  "ar",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_types"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ahash",
  "bitflags 2.9.0",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "paketkoll_utils"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "eyre",
  "paketkoll_types",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "systemd_tmpfiles"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64-simd",
  "bitflags 2.9.0",

--- a/crates/konfigkoll/CHANGELOG.md
+++ b/crates/konfigkoll/CHANGELOG.md
@@ -8,6 +8,16 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.13] - 2025-05-05
+
+### 🚜 Refactoring
+
+- Clean up inter-module cyclic dependencies
+
+### ⚙️ Other stuff
+
+- Update Cargo.toml dependencies
+
 ## [0.1.12] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll/Cargo.toml
+++ b/crates/konfigkoll/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "konfigkoll"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.1.12"
+version = "0.1.13"
 
 [[bin]]
 name = "konfigkoll"
@@ -46,14 +46,14 @@ directories.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_core = { version = "0.5.3", path = "../konfigkoll_core" }
-konfigkoll_script = { version = "0.1.10", path = "../konfigkoll_script" }
-konfigkoll_types = { version = "0.2.6", path = "../konfigkoll_types" }
+konfigkoll_core = { version = "0.5.4", path = "../konfigkoll_core" }
+konfigkoll_script = { version = "0.1.11", path = "../konfigkoll_script" }
+konfigkoll_types = { version = "0.2.7", path = "../konfigkoll_types" }
 konfigkoll_utils = { version = "0.1.8", path = "../konfigkoll_utils" }
 ouroboros.workspace = true
-paketkoll_cache = { version = "0.2.9", path = "../paketkoll_cache" }
-paketkoll_core = { version = "0.5.10", path = "../paketkoll_core" }
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
+paketkoll_cache = { version = "0.2.10", path = "../paketkoll_cache" }
+paketkoll_core = { version = "0.5.11", path = "../paketkoll_core" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 rayon.workspace = true
 rune = { workspace = true, features = ["cli"] }

--- a/crates/konfigkoll_core/CHANGELOG.md
+++ b/crates/konfigkoll_core/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.4] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Update Cargo.toml dependencies
+
 ## [0.5.3] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_core/Cargo.toml
+++ b/crates/konfigkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.5.3"
+version = "0.5.4"
 
 [dependencies]
 ahash.workspace = true
@@ -20,11 +20,11 @@ duct.workspace = true
 either.workspace = true
 eyre.workspace = true
 itertools.workspace = true
-konfigkoll_types = { version = "0.2.6", path = "../konfigkoll_types" }
+konfigkoll_types = { version = "0.2.7", path = "../konfigkoll_types" }
 libc.workspace = true
 nix = { workspace = true, features = ["user"] }
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.9", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.10", path = "../paketkoll_utils" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 parking_lot.workspace = true
 rayon.workspace = true

--- a/crates/konfigkoll_hwinfo/CHANGELOG.md
+++ b/crates/konfigkoll_hwinfo/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.10] - 2025-05-05
+
+### 🚜 Refactoring
+
+- Clean up inter-module cyclic dependencies
+
 ## [0.1.9] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_hwinfo/Cargo.toml
+++ b/crates/konfigkoll_hwinfo/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_hwinfo"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.1.9"
+version = "0.1.10"
 
 [features]
 rune = ["dep:rune"]

--- a/crates/konfigkoll_script/CHANGELOG.md
+++ b/crates/konfigkoll_script/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.11] - 2025-05-05
+
+### 🚜 Refactoring
+
+- Clean up inter-module cyclic dependencies
+
 ## [0.1.10] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_script/Cargo.toml
+++ b/crates/konfigkoll_script/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "konfigkoll_script"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.1.10"
+version = "0.1.11"
 
 [dependencies]
 ahash.workspace = true
@@ -19,12 +19,12 @@ eyre.workspace = true
 glob.workspace = true
 globset.workspace = true
 itertools.workspace = true
-konfigkoll_hwinfo = { version = "0.1.9", path = "../konfigkoll_hwinfo", features = [
+konfigkoll_hwinfo = { version = "0.1.10", path = "../konfigkoll_hwinfo", features = [
     "rune",
 ] }
-konfigkoll_types = { version = "0.2.6", path = "../konfigkoll_types" }
+konfigkoll_types = { version = "0.2.7", path = "../konfigkoll_types" }
 konfigkoll_utils = { version = "0.1.8", path = "../konfigkoll_utils" }
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 parking_lot.workspace = true
 regex.workspace = true

--- a/crates/konfigkoll_types/CHANGELOG.md
+++ b/crates/konfigkoll_types/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.7] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Updated the following local packages: paketkoll_types, paketkoll_utils
+
 ## [0.2.6] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/konfigkoll_types/Cargo.toml
+++ b/crates/konfigkoll_types/Cargo.toml
@@ -6,15 +6,15 @@ license = "MPL-2.0"
 name = "konfigkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.2.6"
+version = "0.2.7"
 
 [dependencies]
 camino.workspace = true
 compact_str.workspace = true
 either.workspace = true
 eyre.workspace = true
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.9", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.10", path = "../paketkoll_utils" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 strum.workspace = true
 

--- a/crates/mtree2/CHANGELOG.md
+++ b/crates/mtree2/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.6.12] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Update Cargo.toml dependencies
+
 ## [0.6.11] - 2025-04-27
 
 ### 🚀 Features

--- a/crates/mtree2/Cargo.toml
+++ b/crates/mtree2/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 name = "mtree2"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
-version = "0.6.11"
+version = "0.6.12"
 
 [dependencies]
 bitflags.workspace = true

--- a/crates/paketkoll/CHANGELOG.md
+++ b/crates/paketkoll/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.3.11] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Update Cargo.toml dependencies
+
 ## [0.3.10] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll/Cargo.toml
+++ b/crates/paketkoll/Cargo.toml
@@ -8,7 +8,7 @@ name = "paketkoll"
 readme = "README.md"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.3.10"
+version = "0.3.11"
 
 [features]
 # Default features
@@ -37,8 +37,8 @@ compact_str.workspace = true
 eyre.workspace = true
 ignore.workspace = true
 os_info.workspace = true
-paketkoll_core = { version = "0.5.10", path = "../paketkoll_core" }
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
+paketkoll_core = { version = "0.5.11", path = "../paketkoll_core" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 proc-exit.workspace = true
 rayon.workspace = true

--- a/crates/paketkoll_cache/CHANGELOG.md
+++ b/crates/paketkoll_cache/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.10] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Updated the following local packages: paketkoll_types
+
 ## [0.2.9] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_cache/Cargo.toml
+++ b/crates/paketkoll_cache/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_cache"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.2.9"
+version = "0.2.10"
 
 [dependencies]
 ahash.workspace = true
@@ -15,7 +15,7 @@ cached.workspace = true
 compact_str.workspace = true
 dashmap.workspace = true
 eyre.workspace = true
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 serde.workspace = true
 smallvec.workspace = true

--- a/crates/paketkoll_core/CHANGELOG.md
+++ b/crates/paketkoll_core/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.5.11] - 2025-05-05
+
+### 🚜 Refactoring
+
+- Clean up inter-module cyclic dependencies
+
 ## [0.5.10] - 2025-04-27
 
 ### 🐛 Bug fixes

--- a/crates/paketkoll_core/Cargo.toml
+++ b/crates/paketkoll_core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_core"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.5.10"
+version = "0.5.11"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"
@@ -70,11 +70,11 @@ glob.workspace = true
 ignore.workspace = true
 libc.workspace = true
 md-5 = { workspace = true, optional = true }
-mtree2 = { version = "0.6.11", path = "../mtree2", optional = true }
+mtree2 = { version = "0.6.12", path = "../mtree2", optional = true }
 nix = { workspace = true, features = ["user"], optional = true }
 num_cpus.workspace = true
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
-paketkoll_utils = { version = "0.1.9", path = "../paketkoll_utils" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
+paketkoll_utils = { version = "0.1.10", path = "../paketkoll_utils" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 parking_lot.workspace = true
 hashify.workspace = true
@@ -85,7 +85,7 @@ rust-ini = { workspace = true, optional = true }
 scopeguard.workspace = true
 smallvec.workspace = true
 strum.workspace = true
-systemd_tmpfiles = { version = "0.2.4", path = "../systemd_tmpfiles", optional = true }
+systemd_tmpfiles = { version = "0.2.5", path = "../systemd_tmpfiles", optional = true }
 tar.workspace = true
 tracing.workspace = true
 xz2 = { workspace = true, optional = true }

--- a/crates/paketkoll_types/CHANGELOG.md
+++ b/crates/paketkoll_types/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.5] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Update Cargo.toml dependencies
+
 ## [0.2.4] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_types/Cargo.toml
+++ b/crates/paketkoll_types/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "paketkoll_types"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.2.4"
+version = "0.2.5"
 
 [dependencies]
 ahash.workspace = true

--- a/crates/paketkoll_utils/CHANGELOG.md
+++ b/crates/paketkoll_utils/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.1.10] - 2025-05-05
+
+### ⚙️ Other stuff
+
+- Updated the following local packages: paketkoll_types
+
 ## [0.1.9] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/paketkoll_utils/Cargo.toml
+++ b/crates/paketkoll_utils/Cargo.toml
@@ -6,11 +6,11 @@ license = "MPL-2.0"
 name = "paketkoll_utils"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.1.9"
+version = "0.1.10"
 
 [dependencies]
 eyre.workspace = true
-paketkoll_types = { version = "0.2.4", path = "../paketkoll_types" }
+paketkoll_types = { version = "0.2.5", path = "../paketkoll_types" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 ring.workspace = true
 

--- a/crates/systemd_tmpfiles/CHANGELOG.md
+++ b/crates/systemd_tmpfiles/CHANGELOG.md
@@ -8,6 +8,12 @@ edited).
 For a possibly more edited message focused on the binary please see the github
 releases.
 
+## [0.2.5] - 2025-05-05
+
+### 🚜 Refactoring
+
+- Clean up inter-module cyclic dependencies
+
 ## [0.2.4] - 2025-04-27
 
 ### ⚙️ Other stuff

--- a/crates/systemd_tmpfiles/Cargo.toml
+++ b/crates/systemd_tmpfiles/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 name = "systemd_tmpfiles"
 repository = "https://github.com/VorpalBlade/paketkoll"
 rust-version = "1.85.0"
-version = "0.2.4"
+version = "0.2.5"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-unknown-linux-gnu"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -31,8 +31,8 @@ clap_complete.workspace = true
 clap_mangen.workspace = true
 color-eyre.workspace = true
 eyre.workspace = true
-konfigkoll = { version = "0.1.12", path = "../konfigkoll" }
-paketkoll = { version = "0.3.10", path = "../paketkoll" }
+konfigkoll = { version = "0.1.13", path = "../konfigkoll" }
+paketkoll = { version = "0.3.11", path = "../paketkoll" }
 paketkoll_workspace_hack = { version = "0.1", path = "../paketkoll_workspace_hack" }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `paketkoll_types`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `konfigkoll_core`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `konfigkoll_hwinfo`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `konfigkoll_script`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `mtree2`: 0.6.11 -> 0.6.12 (✓ API compatible changes)
* `systemd_tmpfiles`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `paketkoll_core`: 0.5.10 -> 0.5.11 (✓ API compatible changes)
* `konfigkoll`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `paketkoll`: 0.3.10 -> 0.3.11 (✓ API compatible changes)
* `paketkoll_utils`: 0.1.9 -> 0.1.10
* `konfigkoll_types`: 0.2.6 -> 0.2.7
* `paketkoll_cache`: 0.2.9 -> 0.2.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `paketkoll_types`

<blockquote>

## [0.2.5] - 2025-05-05

### ⚙️ Other stuff

- Update Cargo.toml dependencies
</blockquote>

## `konfigkoll_core`

<blockquote>

## [0.5.4] - 2025-05-05

### ⚙️ Other stuff

- Update Cargo.toml dependencies
</blockquote>

## `konfigkoll_hwinfo`

<blockquote>

## [0.1.10] - 2025-05-05

### 🚜 Refactoring

- Clean up inter-module cyclic dependencies
</blockquote>

## `konfigkoll_script`

<blockquote>

## [0.1.11] - 2025-05-05

### 🚜 Refactoring

- Clean up inter-module cyclic dependencies
</blockquote>

## `mtree2`

<blockquote>

## [0.6.12] - 2025-05-05

### ⚙️ Other stuff

- Update Cargo.toml dependencies
</blockquote>

## `systemd_tmpfiles`

<blockquote>

## [0.2.5] - 2025-05-05

### 🚜 Refactoring

- Clean up inter-module cyclic dependencies
</blockquote>

## `paketkoll_core`

<blockquote>

## [0.5.11] - 2025-05-05

### 🚜 Refactoring

- Clean up inter-module cyclic dependencies
</blockquote>

## `konfigkoll`

<blockquote>

## [0.1.13] - 2025-05-05

### 🚜 Refactoring

- Clean up inter-module cyclic dependencies

### ⚙️ Other stuff

- Update Cargo.toml dependencies
</blockquote>

## `paketkoll`

<blockquote>

## [0.3.11] - 2025-05-05

### ⚙️ Other stuff

- Update Cargo.toml dependencies
</blockquote>

## `paketkoll_utils`

<blockquote>

## [0.1.10] - 2025-05-05

### ⚙️ Other stuff

- Updated the following local packages: paketkoll_types
</blockquote>

## `konfigkoll_types`

<blockquote>

## [0.2.7] - 2025-05-05

### ⚙️ Other stuff

- Updated the following local packages: paketkoll_types, paketkoll_utils
</blockquote>

## `paketkoll_cache`

<blockquote>

## [0.2.10] - 2025-05-05

### ⚙️ Other stuff

- Updated the following local packages: paketkoll_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).